### PR TITLE
Add Javadoc support to chili annotations

### DIFF
--- a/chili/src/main/java/me/defying/chili/Log.java
+++ b/chili/src/main/java/me/defying/chili/Log.java
@@ -22,6 +22,7 @@
  */
 package me.defying.chili;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -35,6 +36,7 @@ import me.defying.chili.log.LogLevel;
  * @author Rafael Marmelo
  * @since 1.0
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Log {

--- a/chili/src/main/java/me/defying/chili/Memoize.java
+++ b/chili/src/main/java/me/defying/chili/Memoize.java
@@ -22,6 +22,7 @@
  */
 package me.defying.chili;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit;
  * @author Rafael Marmelo
  * @since 1.0
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Memoize {


### PR DESCRIPTION
Modified the annotations so they appear on the javadoc of methods that are using it.
